### PR TITLE
Websocket online user aggregation

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1743,12 +1743,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1763,17 +1765,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1890,7 +1895,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1902,6 +1908,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1916,6 +1923,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1923,12 +1931,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1947,6 +1957,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2027,7 +2038,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2039,6 +2051,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2160,6 +2173,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/lib/slack_inviter/application.ex
+++ b/lib/slack_inviter/application.ex
@@ -12,6 +12,8 @@ defmodule SlackInviter.Application do
       supervisor(SlackInviterWeb.Endpoint, []),
       # Start your own worker by calling: SlackInviter.Worker.start_link(arg1, arg2, arg3)
       # worker(SlackInviter.Worker, [arg1, arg2, arg3]),
+      {SlackInviter.ConnectedUsers, []},
+      {SlackInviter.UserPresenceAgent, []},
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/slack_inviter/connected_users.ex
+++ b/lib/slack_inviter/connected_users.ex
@@ -1,0 +1,57 @@
+defmodule SlackInviter.ConnectedUsers do
+  @moduledoc """
+  A module that connects to the slack api via websockets and listens for `presence_change` events.
+  When it receives one, it adjusts the state of the UserPresenceAgent to reflect the number of
+  online users and broadcasts this value to all clients via an phoenix channel.
+  """
+  use WebSockex
+
+  alias SlackInviter.UserPresenceAgent
+
+  def start_link(_) do
+    case SlackInviter.SlackApi.rtm_connect do
+      {:ok, %{body: response}} -> WebSockex.start_link(response["url"], __MODULE__, "")
+      error -> error
+    end
+  end
+
+  def handle_frame({_type, msg}, _state) do
+    case Poison.decode(msg) do
+      {:ok, state} ->
+        if state["type"] == "presence_change" do
+          aggregate_presence(state)
+        end
+        {:ok, state}
+      {:error, err} -> {:error, err}
+    end
+  end
+
+  def aggregate_presence(%{
+    "type" => "presence_change",
+    "users" => users,
+    "presence" => presence,
+  }) do
+    user_count = Enum.count(users)
+    case presence do
+      "away" -> UserPresenceAgent.decrement(user_count)
+      "active" -> UserPresenceAgent.increment(user_count)
+      _ -> :error
+    end
+  end
+
+  def aggregate_presence(%{
+    "type" => "presence_change",
+    "presence" => presence,
+  }) do
+    case presence do
+      "away" -> UserPresenceAgent.decrement(1)
+      "active" -> UserPresenceAgent.increment(1)
+      _ -> :error
+    end
+  end
+
+  def handle_cast({:send, {type, msg} = frame}, state) do
+    IO.puts "Sending #{type} frame with payload: #{msg}"
+    {:reply, frame, state}
+  end
+end

--- a/lib/slack_inviter/slack_api.ex
+++ b/lib/slack_inviter/slack_api.ex
@@ -15,5 +15,9 @@ defmodule SlackInviter.SlackApi do
   def invite_user(email) do
     post("/users.admin.invite", %{email: email, resend: true, token: @slack_api_token})
   end
+
+  def rtm_connect do
+    get("/rtm.connect", query: [token: @slack_api_token])
+  end
 end
 

--- a/lib/slack_inviter/user_presence_agent.ex
+++ b/lib/slack_inviter/user_presence_agent.ex
@@ -1,0 +1,52 @@
+defmodule SlackInviter.UserPresenceAgent do
+  @moduledoc """
+  This agent is used for keeping track of the number of users online at a given time. When a new
+  user comes online, the increment/1 and decrement/1 methods are called to adjust the user count
+  and broadcast the latest to all clients connected via an phoenix channel.
+  """
+  @name __MODULE__
+
+  alias SlackInviterWeb.Endpoint
+
+  def start_link(_) do
+    Agent.start_link(fn -> 0 end, name: @name)
+  end
+
+  def increment(n) do
+    case Agent.update(@name, fn(state) -> state + n end) do
+      {:ok, pid} ->
+        Endpoint.broadcast("user_presence:lobby", "users_change", assemble_payload())
+        {:ok, pid}
+      error -> error
+    end
+  end
+
+  def decrement(n) do
+    case Agent.update(@name, fn(state) -> state - n end) do
+      {:ok, pid} ->
+        Endpoint.broadcast("user_presence:lobby", "users_change", assemble_payload())
+        {:ok, pid}
+      error -> error
+    end
+  end
+  
+  def assemble_payload do
+    %{
+      "online_count" => get()
+    }
+  end
+
+  def get do
+    Agent.get(@name, fn(state) -> state end)
+  end
+
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      type: :worker,
+      restart: :permanent,
+      shutdown: 500
+    }
+  end
+end

--- a/lib/slack_inviter_web/channels/user_presence_channel.ex
+++ b/lib/slack_inviter_web/channels/user_presence_channel.ex
@@ -1,0 +1,29 @@
+defmodule SlackInviterWeb.UserPresenceChannel do
+  use SlackInviterWeb, :channel
+
+  def join("user_presence:lobby", payload, socket) do
+    if authorized?(payload) do
+      {:ok, socket}
+    else
+      {:error, %{reason: "unauthorized"}}
+    end
+  end
+
+  # Channels can be used in a request/response fashion
+  # by sending replies to requests from the client
+  def handle_in("ping", payload, socket) do
+    {:reply, {:ok, payload}, socket}
+  end
+
+  # It is also common to receive messages from the client and
+  # broadcast to everyone in the current topic (user_presence:lobby).
+  def handle_in("shout", payload, socket) do
+    broadcast socket, "shout", payload
+    {:noreply, socket}
+  end
+
+  # Add authorization logic here as required.
+  defp authorized?(_payload) do
+    true
+  end
+end

--- a/lib/slack_inviter_web/channels/user_socket.ex
+++ b/lib/slack_inviter_web/channels/user_socket.ex
@@ -3,6 +3,7 @@ defmodule SlackInviterWeb.UserSocket do
 
   ## Channels
   # channel "room:*", SlackInviterWeb.RoomChannel
+  channel "user_presence:lobby", SlackInviterWeb.UserPresenceChannel
 
   ## Transports
   transport :websocket, Phoenix.Transports.WebSocket

--- a/mix.exs
+++ b/mix.exs
@@ -40,6 +40,7 @@ defmodule SlackInviter.Mixfile do
       {:cowboy, "~> 1.0"},
       {:tesla, "~> 1.0.0"},
       {:jason, "~> 1.0"},
+      {:websockex, "~> 0.4.0"},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -13,4 +13,5 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
   "tesla": {:hex, :tesla, "1.0.0", "94a9059456d51266f3d40b75ff6be3d18496072ce5ffaabad03d6c00f065cfd1", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: true]}, {:fuse, "~> 2.4", [hex: :fuse, repo: "hexpm", optional: true]}, {:hackney, "~> 1.6", [hex: :hackney, repo: "hexpm", optional: true]}, {:ibrowse, "~> 4.4.0", [hex: :ibrowse, repo: "hexpm", optional: true]}, {:jason, ">= 1.0.0", [hex: :jason, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:poison, ">= 1.0.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
+  "websockex": {:hex, :websockex, "0.4.1", "d7b7191ec3d5dd136683b60114405a5a130a175faade773a07cb52dbd98f9442", [:mix], [], "hexpm"},
 }

--- a/test/slack_inviter_web/channels/user_presence_channel_test.exs
+++ b/test/slack_inviter_web/channels/user_presence_channel_test.exs
@@ -1,0 +1,28 @@
+defmodule SlackInviterWeb.UserPresenceChannelTest do
+  use SlackInviterWeb.ChannelCase
+
+  alias SlackInviterWeb.UserPresenceChannel
+
+  setup do
+    {:ok, _, socket} =
+      socket("user_id", %{some: :assign})
+      |> subscribe_and_join(UserPresenceChannel, "user_presence:lobby")
+
+    {:ok, socket: socket}
+  end
+
+  test "ping replies with status ok", %{socket: socket} do
+    ref = push socket, "ping", %{"hello" => "there"}
+    assert_reply ref, :ok, %{"hello" => "there"}
+  end
+
+  test "shout broadcasts to user_presence:lobby", %{socket: socket} do
+    push socket, "shout", %{"hello" => "all"}
+    assert_broadcast "shout", %{"hello" => "all"}
+  end
+
+  test "broadcasts are pushed to the client", %{socket: socket} do
+    broadcast_from! socket, "broadcast", %{"some" => "data"}
+    assert_push "broadcast", %{"some" => "data"}
+  end
+end


### PR DESCRIPTION
Work in progress PR to add a live updating online user count to the slack invitation system for syracuse.io.

- Connect to the rtm slack api with `ConnectedUsers`
- When the number of online users changes,
aggregate the total in the `UserPresenceAgent` and broadcast on the `UserPresenceChannel`.

@vormwald The backend portion of this is complete. All that's left is the javascript on the client to read the value from the channel and update the web page. If you don't get to it before next openhack, I'll probably finish it up then.