### PR TITLE
Notify slack on new invitations

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -15,7 +15,8 @@ config :slack_inviter, SlackInviterWeb.Endpoint,
 
 config :slack_inviter,
   slack_api_base_url: System.get_env("SLACK_API_BASE") || "https://slack.com/api",
-  slack_api_token: System.get_env("SLACK_API_TOKEN")
+  slack_api_token: System.get_env("SLACK_API_TOKEN"),
+  slack_notify_channel: System.get_env("SLACK_NOTIFY_CHANNEL")
 
 # Configures Elixir's Logger
 config :logger, :console,

--- a/lib/slack_client/mock_server.ex
+++ b/lib/slack_client/mock_server.ex
@@ -35,6 +35,23 @@ defmodule SlackClient.MockServer do
     ]})
   end
 
+  post "chat.postMessage" do
+    success(conn, %{ok: true,
+      channel: "SLACK_ID_FOR_CHANNEL",
+      message: %{
+        type: "message",
+        subtype: "bot_message",
+        text: conn.params["text"],
+        username: conn.params["username"],
+        icons: %{
+            emoji: conn.params["icon_emoji"],
+            image_64: "https:\/\/a.slack-edge.com\/emoji.png"
+        },
+        bot_id: "R2D2"
+    }})
+
+  end
+
   # A catchall route, 'match' will match no matter the request method,
   # so a response is always returned, even if there is no route to match.
   match _ do

--- a/lib/slack_inviter/slack_api.ex
+++ b/lib/slack_inviter/slack_api.ex
@@ -3,6 +3,7 @@ defmodule SlackInviter.SlackApi do
 
   @slack_api_base_url Application.get_env(:slack_inviter, :slack_api_base_url)
   @slack_api_token Application.get_env(:slack_inviter, :slack_api_token)
+  @slack_notify_channel Application.get_env(:slack_inviter, :slack_notify_channel)
 
   plug Tesla.Middleware.BaseUrl, @slack_api_base_url
   plug Tesla.Middleware.FormUrlencoded
@@ -14,6 +15,15 @@ defmodule SlackInviter.SlackApi do
 
   def invite_user(email) do
     post("/users.admin.invite", %{email: email, resend: true, token: @slack_api_token})
+  end
+
+  def notify_invited(email) do
+    post("/chat.postMessage", %{channel: @slack_notify_channel,
+      text: "Invited #{email}",
+      as_user: false,
+      username: "InviteBot",
+      icon_emoji: ":chart_with_upwards_trend:",
+      token: @slack_api_token})
   end
 end
 

--- a/lib/slack_inviter/users.ex
+++ b/lib/slack_inviter/users.ex
@@ -1,14 +1,16 @@
 defmodule SlackInviter.Users do
   require Logger
+  alias SlackInviter.SlackApi
 
   def invite(email) do
-    {:ok, %{body: response}} = SlackInviter.SlackApi.invite_user(email)
+    {:ok, %{body: response}} = SlackApi.invite_user(email)
     parse_invite email, response
   end
 
   def parse_invite(email, response) do
     case response do
       %{"ok" => true} ->
+        notify_slack(email)
         {:ok, "success"}
       %{"ok" => false} ->
         Logger.info "Fail " <> email <> " : " <> response["error"]
@@ -16,9 +18,8 @@ defmodule SlackInviter.Users do
     end
   end
 
-
   def list do
-    {:ok, %{body: response}} = SlackInviter.SlackApi.list_users
+    {:ok, %{body: response}} = SlackApi.list_users
     parse_list response
   end
 
@@ -41,6 +42,21 @@ defmodule SlackInviter.Users do
         {:ok, results}
       %{"ok" => false} ->
         Logger.info "Fail "<> response["error"]
+        {:error, response["error"]}
+    end
+  end
+
+  def notify_slack(email) do
+    {:ok, %{body: response}} = SlackApi.notify_invited(email)
+    parse_notify_slack email, response
+  end
+
+  def parse_notify_slack(email, response) do
+    case response do
+      %{"ok" => true} ->
+        {:ok, "success"}
+      %{"ok" => false} ->
+        Logger.info "Could not send notification to slack: " <> email <> " : " <> response["error"]
         {:error, response["error"]}
     end
   end

--- a/test/slack_inviter/slack_api_test.exs
+++ b/test/slack_inviter/slack_api_test.exs
@@ -14,7 +14,6 @@ defmodule SlackInviter.SlackApiTest do
     end
   end
 
-
   describe "SlackApi.invite_user" do
     test "When a user is new, invite them to slack" do
         email = "newbie@syracuse.io"
@@ -35,6 +34,21 @@ defmodule SlackInviter.SlackApiTest do
             assert res["error"] == "already_in_team"
           {:error, err} -> flunk err
       end
+    end
+  end
+
+  describe "SlackApi.notify_invited" do
+    test "Alert slack channel" do
+        email = "newbie@syracuse.io"
+
+        case SlackApi.notify_invited(email) do
+          {:ok, %{body: res} } ->
+            assert res["ok"] == true
+            assert res["message"]["text"] == "Invited #{email}"
+            assert res["message"]["username"] == "InviteBot"
+            assert res["message"]["icons"]["emoji"] == ":chart_with_upwards_trend:"
+          {:error, err} -> flunk err
+        end
     end
   end
 end


### PR DESCRIPTION
### Problem

I'd like to have a better idea of who is joining the community slack.

### Solution

Start by collecting the email addresses they use to sign up. This should help spot sketchy email addresses, but also opens the door to integrating with clearbit.com to get more information about the folks joining

This change will begin posting emails to a private slack channel to begin this process