### PR TITLE
Bugfix: Slack changed their API & it broke the site

### DIFF
--- a/lib/slack_inviter/users.ex
+++ b/lib/slack_inviter/users.ex
@@ -35,20 +35,15 @@ defmodule SlackInviter.Users do
   def parse_list(response) do
     case response do
       %{"ok" => true} ->
-        partitioned = response
-                      |> Map.get("members")
-                      |> Enum.group_by(fn(member) ->
-                        member["presence"]
-                      end)
-        results = %{ active: active_user_count(partitioned),
-                     away:   Enum.count(partitioned["away"]) }
+        count = response
+                  |> Map.get("members")
+                  |> Enum.reject(fn member -> member["deleted"] == true end)
+                  |> Enum.count
+        results = %{ active: count }
         {:ok, results}
       %{"ok" => false} ->
         Logger.info "Fail "<> response["error"]
         {:error, response["error"]}
     end
   end
-
-  defp active_user_count(%{"active" => active}), do: Enum.count(active)
-  defp active_user_count(_), do: 0
 end

--- a/lib/slack_inviter_web/templates/page/index.html.eex
+++ b/lib/slack_inviter_web/templates/page/index.html.eex
@@ -4,8 +4,7 @@
 <hr>
 
 <p>
-Come join the <strong><%= active_member_count(@members) %> members currently online</strong>,
-and <strong><%= total_member_count(@members) %> total members</strong>.
+Come join <%= @members[:active] %> Syracuse developers
 </p>
 
 <%= form_for @conn,  invite_path(@conn, :create), [as: :register, method: :post], fn f -> %>

--- a/lib/slack_inviter_web/views/page_view.ex
+++ b/lib/slack_inviter_web/views/page_view.ex
@@ -1,10 +1,4 @@
 defmodule SlackInviterWeb.PageView do
   use SlackInviterWeb, :view
-
-  def active_member_count(%{active: active}), do: active
-  def active_member_count(_), do: 0
-
-  def total_member_count(%{active: active, away: away}), do: active + away
-  def total_member_count(_), do: 0
 end
 

--- a/test/slack_inviter/users_test.exs
+++ b/test/slack_inviter/users_test.exs
@@ -3,29 +3,15 @@ defmodule SlackInviter.UsersTest do
 
   alias SlackInviter.Users
 
-  describe "Users.list" do
-    test "parses users into active and away" do
-      response = %{"ok" => true, "members" => [
-            %{ "real_name" => "Aleksandra", "presence" => "active"},
-            %{ "real_name" => "Aleksandra", "presence" => "away"},
-          ]}
-      case Users.parse_list(response) do
-        {:ok, res} ->
-          assert res == %{active: 1, away: 1}
-        {:error, err} -> flunk err
-      end
-    end
-  end
-
-  describe "when there are note active users" do
+  describe "when there are 2 slack users" do
     test "it returns 0 active users" do
       response = %{"ok" => true, "members" => [
-            %{ "real_name" => "Aleksandra", "presence" => "away"},
-            %{ "real_name" => "Aleksandra", "presence" => "away"},
+            %{ "real_name" => "Aleksandra" },
+            %{ "real_name" => "James"},
           ]}
       case Users.parse_list(response) do
         {:ok, res} ->
-          assert res == %{active: 0, away: 2}
+          assert res == %{active: 2}
         {:error, err} -> flunk err
       end
     end

--- a/test/slack_inviter_web/controllers/page_controller_test.exs
+++ b/test/slack_inviter_web/controllers/page_controller_test.exs
@@ -5,7 +5,6 @@ defmodule SlackInviterWeb.PageControllerTest do
       conn = get conn, "/"
 
       assert html_response(conn, 200) =~ "Syracuse Developer Slack"
-      assert html_response(conn, 200) =~ "1 members currently online"
-      assert html_response(conn, 200) =~ "2 total members"
+      assert html_response(conn, 200) =~ "join 2 Syracuse developers"
   end
 end


### PR DESCRIPTION
### Problem

Slack deprecated the "presence" value in `users.list`'s response. This breaks the way we were displaying active/total users on the home page.

### Solution
Change the api response processing to simply count all members, and use that to display on the homepage
